### PR TITLE
Add cookbook name 'tracelytics' to metadata.rb.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 This file is used to list changes made in each version of tracelytics.
 
+## 0.0.8
+* Add cookbook name to metadata.rb for berkshelf support.
+
 ## 0.0.7
 * customizable apache oboe.conf template, cleaner default attributes 
 

--- a/metadata.rb
+++ b/metadata.rb
@@ -1,6 +1,7 @@
+name             "tracelytics"
 maintainer       "YOUR_COMPANY_NAME"
 maintainer_email "YOUR_EMAIL"
 license          "All rights reserved"
 description      "Installs/Configures tracelytics"
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          "0.0.7"
+version          "0.0.8"


### PR DESCRIPTION
This allows the cookbook to be installed via berkshelf.

While chef server doesn't strictly enforce the inclusion of the name setting in the
metadata, the documentation actually describes it as being required.

Reference: https://docs.chef.io/cookbook_repo.html